### PR TITLE
Make returnImmediately configurable

### DIFF
--- a/src/Connectors/PubSubConnector.php
+++ b/src/Connectors/PubSubConnector.php
@@ -32,7 +32,8 @@ class PubSubConnector implements ConnectorInterface
             $config['subscriber'] ?? 'subscriber',
             $config['create_topics'] ?? true,
             $config['create_subscriptions'] ?? true,
-            $config['queue_prefix'] ?? ''
+            $config['queue_prefix'] ?? '',
+            $config['return_immediately'] ?? true
         );
     }
 

--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -55,19 +55,34 @@ class PubSubQueue extends Queue implements QueueContract
     protected $queuePrefix = '';
 
     /**
+     * If the pull requests should return immediately.
+     *
+     * @var bool
+     */
+    protected $returnImmediately;
+
+    /**
      * Create a new GCP PubSub instance.
      *
      * @param \Google\Cloud\PubSub\PubSubClient $pubsub
      * @param string $default
      */
-    public function __construct(PubSubClient $pubsub, $default, $subscriber = 'subscriber', $topicAutoCreation = true, $subscriptionAutoCreation = true, $queuePrefix = '')
-    {
+    public function __construct(
+        PubSubClient $pubsub,
+        $default,
+        $subscriber = 'subscriber',
+        $topicAutoCreation = true,
+        $subscriptionAutoCreation = true,
+        $queuePrefix = '',
+        $returnImmediately = true
+    ) {
         $this->pubsub = $pubsub;
         $this->default = $default;
         $this->subscriber = $subscriber;
         $this->topicAutoCreation = $topicAutoCreation;
         $this->subscriptionAutoCreation = $subscriptionAutoCreation;
         $this->queuePrefix = $queuePrefix;
+        $this->returnImmediately = $returnImmediately;
     }
 
     /**
@@ -163,7 +178,7 @@ class PubSubQueue extends Queue implements QueueContract
 
         $subscription = $topic->subscription($this->getSubscriberName());
         $messages = $subscription->pull([
-            'returnImmediately' => true,
+            'returnImmediately' => $this->returnImmediately ?? true,
             'maxMessages' => 1,
         ]);
 


### PR DESCRIPTION
This option is deprecated according to GCP documentation and may sometimes return empty responses when there are actual messages in the subscription, but it is not able to retrieve them immediately.