### PR TITLE
feat: Add json output flag

### DIFF
--- a/src/Commands/PubSubConsume.php
+++ b/src/Commands/PubSubConsume.php
@@ -15,7 +15,8 @@ class PubSubConsume extends Command
                             {--sleep=3 : Number of seconds to sleep when no job is available}
                             {--connection=pubsub : The maximum number of seconds the worker should run}
                             {--max-time=0 : The maximum number of seconds the worker should run}
-                            {--memory=128 : The memory limit in megabytes}';
+                            {--memory=128 : The memory limit in megabytes}
+                            {--json : Print the output in JSON format}';
 
     /**
      * @var string
@@ -42,6 +43,7 @@ class PubSubConsume extends Command
             '--sleep' => $this->getSleepOption(),
             '--max-time' => $this->getMaxTimeOption(),
             '--memory' => $this->getMemoryOption(),
+            '--json' => $this->getJsonOption(),
         ];
     }
 
@@ -93,5 +95,13 @@ class PubSubConsume extends Command
     private function getMemoryOption(): string
     {
         return $this->option('memory');
+    }
+
+    /**
+     * @return bool
+     */
+    private function getJsonOption(): bool
+    {
+        return (bool)$this->option('json');
     }
 }


### PR DESCRIPTION
This pull request introduces a new `--json` option to the `PubSubConsume` command, allowing the output to be printed in JSON format. The changes include updates to the command's signature, options handling, and a new helper method for retrieving the `--json` option.

### Addition of `--json` option:

* Updated the command signature in `src/Commands/PubSubConsume.php` to include the `--json` option, which enables JSON-formatted output.
* Added `--json` to the list of options returned by the `getOptions` method, ensuring it is properly recognized and processed.
* Introduced a new private method `getJsonOption` to retrieve and cast the value of the `--json` option as a boolean.