### PR TITLE
Allow Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     "require": {
         "php" : ">=7.2|^8.0",
         "ext-json": "*",
-        "illuminate/queue": "^12.0|^13.0",
-        "illuminate/support": "^12.0|^13.0",
+        "illuminate/queue": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
         "google/cloud-pubsub": "^1.1",
         "ramsey/uuid": "^2.0|^3.0|^4.0"
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended Laravel component dependency support to include Laravel 11 alongside existing Laravel 12 and 13 compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->