### PR TITLE
fix: use hostinger namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This package is a Laravel queue driver that uses the [Google PubSub](https://git
 You can easily install this package with [Composer](https://getcomposer.org) by running this command :
 
 ```bash
-composer require kainxspirits/laravel-pubsub-queue
+composer require hostinger/laravel-pubsub-queue
 ```
 
 If you disabled package discovery, you can still manually register this package by adding the following line to the providers of your `config/app.php` file :

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,7 @@
 {
-    "name": "kainxspirits/laravel-pubsub-queue",
+    "name": "hostinger/laravel-pubsub-queue",
     "description": "Queue driver for Google Cloud Pub/Sub.",
     "keywords": [
-        "kainxspirits",
         "laravel",
         "queue",
         "gcp",
@@ -20,8 +19,8 @@
     "require": {
         "php" : ">=7.2|^8.0",
         "ext-json": "*",
-        "illuminate/queue": "^12.0|^13.0",
-        "illuminate/support": "^12.0|^13.0",
+        "illuminate/queue": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
         "google/cloud-pubsub": "^1.1",
         "ramsey/uuid": "^2.0|^3.0|^4.0"
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Laravel 11.

* **Chores**
  * Updated package vendor name to `hostinger/laravel-pubsub-queue` (previously `kainxspirits/laravel-pubsub-queue`). Users will need to update their installation command accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->